### PR TITLE
Shulker and Endermite entities off by one each

### DIFF
--- a/mcpe_viz.xml
+++ b/mcpe_viz.xml
@@ -1193,8 +1193,8 @@
     <entity id="0x32" name="NPC" etype="P" /> <!-- 0.16? --> <!-- todo what is this? -->
     <entity id="0x33" name="Wither" etype="H" /> <!-- 0.16 -->
     <entity id="0x34" name="Ender Dragon" etype="H" /> <!-- 0.17 -->
-    <entity id="0x35" name="Shulker" etype="H" /> <!-- 0.17 -->
-    <entity id="0x36" name="Endermite" etype="H" /> <!-- 0.17 -->
+    <entity id="0x36" name="Shulker" etype="H" /> <!-- 0.17 -->
+    <entity id="0x37" name="Endermite" etype="H" /> <!-- 0.17 -->
     <entity id="0x3F" name="The Player" />
     <entity id="0x40" name="Dropped item" />
     <entity id="0x41" name="Primed TNT" />


### PR DESCRIPTION
This commit is to fix the listings for Shulker and Endermite entity values being off by one.