### PR TITLE
Add NetBSD Support

### DIFF
--- a/mcpe_viz.cc
+++ b/mcpe_viz.cc
@@ -5338,7 +5338,11 @@ namespace mcpe_viz {
 
     control.init();
 
+#if defined(__NetBSD__)
+    while ((optc = getopt_long (argc, argv, "", longoptlist, &option_index)) != -1) {
+#else
     while ((optc = getopt_long_only (argc, argv, "", longoptlist, &option_index)) != -1) {
+#endif
       switch (optc) {
       case 'O':
         control.fnOutputBase = optarg;

--- a/mcpe_viz.util.cc
+++ b/mcpe_viz.util.cc
@@ -270,10 +270,10 @@ namespace mcpe_viz {
     }
     if ( fmem != NULL ) {
       result = write(output, fmem, fileinfo.st_size);
+      munmap(fmem, fileinfo.st_size);
     } else {
       result = -1;
     }
-    munmap(fmem, fileinfo.st_size);
 #else
     //sendfile will work with non-socket output (i.e. regular file) on Linux 2.6.33+
     off_t bytesCopied = 0;


### PR DESCRIPTION
I fixed to build on NetBSD platform.

Detail:
 1. NetBSD doesn't have getopt_long_only(3), so use getopt_long(3).
 2. NetBSD doesn't have sendfile(2), so replace it with mmap(2)/write(2) combination.

These changes are wrapped by defined(__NetBSD__) compile-time option.
I hope that these are conflicted in any other OSes.